### PR TITLE
Rewrite iterators in iterable/iterator pattern

### DIFF
--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,5 +1,6 @@
 pub const ReadError = error{
-    UninitializedOrSpentIterator,
+    UninitializedIterator,
+    SpentIterator,
     UnionIdOutOfBounds,
     UnexpectedEndOfBuffer,
     IntegerOverflow,

--- a/src/iterable.zig
+++ b/src/iterable.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 pub fn Iterable(comptime T: type) type {
     return struct {
         ptr: *anyopaque,
-        /// null for unknown is a valid, common value
         iteratorFn: *const fn (ptr: *anyopaque) Iterator(T),
         /// Invalidates previously returned iterators
         pub fn iterator(self: *Iterable(T)) Iterator(T) {

--- a/src/iterable.zig
+++ b/src/iterable.zig
@@ -1,0 +1,199 @@
+const std = @import("std");
+
+pub fn Iterable(comptime T: type) type {
+    return struct {
+        ptr: *anyopaque,
+        /// null for unknown is a valid, common value
+        iteratorFn: *const fn (ptr: *anyopaque) Iterator(T),
+        /// Invalidates previously returned iterators
+        pub fn iterator(self: *Iterable(T)) Iterator(T) {
+            return self.iteratorFn(self.ptr);
+        }
+    };
+}
+
+pub fn Iterator(comptime T: type) type {
+    return struct {
+        ptr: *anyopaque,
+        nextFn: *const fn (ptr: *anyopaque) anyerror!?*T,
+        /// Invalidates previously returned items
+        pub fn next(self: *@This()) !?*T {
+            return self.nextFn(self.ptr);
+        }
+    };
+}
+
+pub fn HashMapWithIterable(comptime MapEntry: type) type {
+    const V = std.meta.fieldInfo(MapEntry, .value).type;
+    const Ctx = struct {
+        stuff: *std.StringHashMap(V) = undefined,
+        it: std.StringHashMap(V).Iterator = undefined,
+        cursor: MapEntry = undefined,
+    };
+    const Gen = struct {
+        pub fn iterator(ptr: *anyopaque) Iterator(MapEntry) {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            ctx.it = ctx.stuff.iterator();
+            return Iterator(MapEntry){
+                .ptr = ptr,
+                .nextFn = @This().next,
+            };
+        }
+        pub fn next(ptr: *anyopaque) !?*MapEntry {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            if (ctx.it.next()) |entry| {
+                ctx.cursor = .{ .key = entry.key_ptr.*, .value = entry.value_ptr.* };
+                return &ctx.cursor;
+            } else return null;
+        }
+    };
+    return struct {
+        ctx: Ctx = .{},
+        map: std.StringHashMap(V),
+        pub fn init(allocator: std.mem.Allocator) @This() {
+            const m = std.StringHashMap(V).init(allocator);
+            return .{ .map = m };
+        }
+        pub fn deinit(self: *@This()) void {
+            self.map.deinit();
+        }
+        pub fn iterable(self: *@This()) Iterable(MapEntry) {
+            self.ctx.stuff = &self.map;
+            return Iterable(MapEntry){ .ptr = &self.ctx, .iteratorFn = Gen.iterator };
+        }
+    };
+}
+
+pub fn IterableMappingContext(comptime In: type, comptime Out: type, comptime Mapper: type) type {
+    const Ctx = struct {
+        mapper: *Mapper = undefined,
+        src: *Iterable(In) = undefined,
+        srcIt: Iterator(In) = undefined,
+        cursor: Out = undefined,
+    };
+    const Gen = struct {
+        pub fn iterator(ptr: *anyopaque) Iterator(Out) {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            ctx.srcIt = ctx.src.iterator();
+            return Iterator(Out){
+                .ptr = ptr,
+                .nextFn = @This().next,
+            };
+        }
+        pub fn next(ptr: *anyopaque) !?*Out {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            if (try ctx.srcIt.next()) |v| {
+                try ctx.mapper.map(v, &ctx.cursor);
+                return &ctx.cursor;
+            } else return null;
+        }
+    };
+    return struct {
+        ctx: Ctx = undefined,
+        pub fn iterable(self: *@This(), mapper: *Mapper, src: *Iterable(In)) Iterable(Out) {
+            self.ctx = .{ .mapper = mapper, .src = src };
+            return Iterable(Out){ .ptr = &self.ctx, .iteratorFn = Gen.iterator };
+        }
+    };
+}
+
+pub fn SliceIterableContext(comptime T: type) type {
+    const Ctx = struct {
+        items: []T = undefined,
+        pos: usize = undefined,
+    };
+    const Gen = struct {
+        pub fn iterator(ptr: *anyopaque) Iterator(T) {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            ctx.pos = 0;
+            return Iterator(T){
+                .ptr = ptr,
+                .nextFn = @This().next,
+            };
+        }
+        pub fn next(ptr: *anyopaque) !?*T {
+            var ctx: *Ctx = @ptrCast(@alignCast(ptr));
+            if (ctx.pos > ctx.items.len) return error.SpentIterator;
+            defer ctx.pos += 1;
+            if (ctx.pos == ctx.items.len) return null;
+            const c: *T = &ctx.items[ctx.pos];
+            return c;
+        }
+    };
+    return struct {
+        ctx: Ctx = undefined,
+        pub fn iterable(self: *@This(), items: []T) Iterable(T) {
+            self.ctx = .{ .items = items };
+            return Iterable(T){ .ptr = &self.ctx, .iteratorFn = Gen.iterator };
+        }
+    };
+}
+
+test "hashmapiterator" {
+    const MapEntry = struct {
+        key: []const u8,
+        value: i32,
+        pub fn enjoy(self: @This()) bool {
+            return self.key.len == self.value;
+        }
+    };
+    var hm = HashMapWithIterable(MapEntry).init(std.testing.allocator);
+    defer hm.deinit();
+    try hm.map.put("cheese", 6);
+    var hmi = hm.iterable();
+    var it = hmi.iterator();
+    try std.testing.expect((try it.next()).?.enjoy());
+    try std.testing.expectEqual(null, try it.next());
+    try hm.map.put("ham", 3);
+    it = hmi.iterator();
+    try std.testing.expect((try it.next()).?.enjoy());
+    try std.testing.expect((try it.next()).?.enjoy());
+    try std.testing.expectEqual(null, try it.next());
+}
+
+test "sliceiterable" {
+    var ic = SliceIterableContext(i37){};
+    var arr = [_]i37{ 1, 1, 3, 5, 8 };
+    var i = ic.iterable(&arr);
+    var it = i.iterator();
+    try std.testing.expectEqual(1, (try it.next()).?.*);
+    try std.testing.expectEqual(1, (try it.next()).?.*);
+    try std.testing.expectEqual(3, (try it.next()).?.*);
+    it = i.iterator();
+    try std.testing.expectEqual(1, (try it.next()).?.*);
+    try std.testing.expectEqual(1, (try it.next()).?.*);
+    try std.testing.expectEqual(3, (try it.next()).?.*);
+    try std.testing.expectEqual(5, (try it.next()).?.*);
+    try std.testing.expectEqual(8, (try it.next()).?.*);
+    try std.testing.expectEqual(null, try it.next());
+    try std.testing.expectError(error.SpentIterator, it.next());
+}
+
+test "mapping" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const FmtMapper = struct {
+        alloc: std.mem.Allocator,
+        pub fn map(self: @This(), n: *const i37, m: *[]const u8) !void {
+            m.* = try std.fmt.allocPrint(self.alloc, "Number({d})", .{n.*});
+        }
+    };
+    var mapper = FmtMapper{ .alloc = arena.allocator() };
+    var srcCtx = SliceIterableContext(i37){};
+    var arr = [_]i37{ 1, 1, 3, 5, 8 };
+    var src = srcCtx.iterable(&arr);
+    var mapCtx = IterableMappingContext(i37, []const u8, FmtMapper){};
+    var mapperIterable = mapCtx.iterable(&mapper, &src);
+    var it = mapperIterable.iterator();
+    try std.testing.expectEqualStrings("Number(1)", (try it.next()).?.*);
+    try std.testing.expectEqualStrings("Number(1)", (try it.next()).?.*);
+    try std.testing.expectEqualStrings("Number(3)", (try it.next()).?.*);
+    try std.testing.expectEqualStrings("Number(5)", (try it.next()).?.*);
+    try std.testing.expectEqualStrings("Number(8)", (try it.next()).?.*);
+    try std.testing.expectEqual(null, try it.next());
+    try std.testing.expectError(error.SpentIterator, it.next());
+}
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -109,24 +109,6 @@ test "uninitialized iterators are bad" {
     try std.testing.expectError(error.NoIterator, it.next());
 }
 
-fn Shitterable(comptime T: type, items: []T) type {
-    const Shitterator = struct {
-        pos: usize,
-        items: []T,
-        pub fn iterator(self: *const @This()) iter.Iterator(T) {
-            return iter.Iterator(T).init(self, 0, 0);
-        }
-        pub fn next(self: *const @This(), item: *T, pos: *usize, _: *i64) ?T {
-            defer pos.* += 1;
-            if (pos.* > self.items.len) return error.IteratorPastEnd;
-            if (pos.* == self.items.len) return null;
-            item.* = items[pos.*];
-            return item.*;
-        }
-    };
-    return iter.Iterable(T).init(Shitterator);
-}
-
 pub fn encode(comptime T: type, self: *T, writer: anytype) !usize {
     return try Writer.write(T, writer, self);
 }

--- a/src/string.zig
+++ b/src/string.zig
@@ -8,9 +8,8 @@ pub fn read(dst: *[]const u8, in: []const u8) !usize {
     var len_i64: i64 = 0;
     const n = try number.readLong(&len_i64, in);
     const len: usize = @intCast(len_i64);
-    if (in.len < len) {
+    if (in.len < len)
         return error.UnexpectedEndOfBuffer;
-    }
     dst.* = in[n .. n + len];
     return n + len;
 }
@@ -49,7 +48,6 @@ test write {
     const out = try write(&writer, res);
     try std.testing.expectEqual(3, out);
     try std.testing.expectEqualStrings(res, buf[1..]);
-
 
     const res2 = "🤪🤑🤑🤑🤑";
     var buf2: [res2.len + 1]u8 = undefined;


### PR DESCRIPTION
This is a way to allow repeated and independent iteration of Array and Map values, without allocating iterators.

Also allows insertion of other iterable sources of data when serializing, which have their own state and context.

Added helpers for creating Iterables:
- Based on std.AutoHashMap, for writing Map values.
- From a slice, intended for test data.
- Higher order function-ish "map" over an existing iterator.