### PR TITLE
Correct optional "reset" code

### DIFF
--- a/src/reader.zig
+++ b/src/reader.zig
@@ -39,7 +39,9 @@ pub fn readOptional(comptime T: type, v: *?T, buf: []const u8) !usize {
         v.* = null;
         return 1;
     }
-    v.* = std.mem.zeroes(T);
+    // This flips off the "is null" flag without doing anything to the
+    // underlying data.
+    v.* = undefined;
     return 1 + try read(T, &(v.*.?), buf[1..]);
 }
 


### PR DESCRIPTION
When deserializing an optional, we need to both mark the optional tag as "has value" in case it was "has null" from a previously parsed element.

Setting the value to an explicit "everything is zero" instance was the clearest safe option, but this breaks down when we have cool shit like anyopaque pointers and function pointers which can't be set to 0.

Instead, we lean on the safe but scary-looking behavior of setting undefined values.  For optionals, this has two effects based on the type:
- Most stuff: flip the "value" flag ON but otherwise leave the contents unchanged. This is fine, as we now can vomit data into the data area and the entire thing will be an optional with a value.
- Pointers: do nothing (because a pointer to address 0 is the implicit null flag, so as soon as we set a value, it is not null.
- Slices: does like pointers.